### PR TITLE
fix(package): add missing dependency "make-error"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "lodash.get": "^4",
+    "make-error": "^1.3.5",
     "ts-node": "^7",
     "tslib": "^1.9.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3923,7 +3923,7 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@1.x, make-error@^1.1.1, make-error@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader/blob/develop/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer for your PR to be merged
-->

## What did you implement:

Add "make-error" to package.json "dependencies", so that it can be resolved by Node.js, to prevent issues like https://github.com/apollographql/apollo-tooling/issues/1070

To reproduce the original problem:

```
$ npm install --global pnpm
$ pnpm install @endemolshinegroup/cosmiconfig-typescript-loader
$ node -r '@endemolshinegroup/cosmiconfig-typescript-loader'
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'make-error'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/spencerelliott/Dev/elliottsj/cosmiconfig-test/node_modules/.registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/1.0.0/node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/dist/Errors/TypeScriptCompileError.js:3:22)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Manually add it to package.json, then run `yarn` to update the lockfile.

## How can we verify it:

```
# first check out this branch, then:
$ npm run build
$ npm install --global pnpm
$ mkdir ../testdir
$ cd ../testdir
$ pnpm install ../cosmiconfig-typescript-loader/
$ node -r '@endemolshinegroup/cosmiconfig-typescript-loader'
> // no errors
```

<!--
Add any applicable config, commands, screenshots or other resources to make it easy for us to verify this works. The easier you make it for us to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the `develop` branch
* Other - Anything else that comes to mind to help us evaluate
-->

## Tasks:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
