### PR TITLE
wrong engine being used

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "url": "https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader.git"
   },
   "engines": {
-    "node": ">=10.0.0",
-    "yarn": ">=1.3.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "pretest": "rimraf coverage/",


### PR DESCRIPTION
fixes #77

```
error @endemolshinegroup/cosmiconfig-typescript-loader@1.0.2: The engine "yarn" is incompatible with this module. Expected version ">=1.3.0".
error Found incompatible module
```