### PR TITLE
fix: remove unnecessary `async` keyword

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import get from 'lodash.get';
 
 import TypeScriptCompileError from './Errors/TypeScriptCompileError';
 
-const loader: Loader = async (filePath: string) => {
+const loader: Loader = (filePath: string) => {
   try {
     require('ts-node/register');
     const result = require(filePath);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader/blob/develop/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer for your PR to be merged
-->

## What did you implement:

I've removed the `async` keyword to make the loader compatible with `cosmiconfigSync()`.

## How did you implement it:

See above :)

## How can we verify it:

Try to use the plugin with `cosmiconfigSync()`.

## Tasks:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
