### PR TITLE
Add typescript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lint": "tslint -p tsconfig.json -t codeFrame 'src/**/*.ts' -e 'src/**/*.spec.ts'"
   },
   "peerDependencies": {
-    "cosmiconfig": ">=6"
+    "cosmiconfig": ">=6",
+    "typescript": ">=2.7"
   },
   "dependencies": {
     "lodash.get": "^4",


### PR DESCRIPTION
## What did you implement:

`typescript` is a peer dependency of `ts-node`. Therefore it needs to be provided by this package; I have added it as a peer dependency.

## How did you implement it:

See above.

## How can we verify it:

* See that `typescript` it is a peer dependency of `ts-node` [here](https://github.com/TypeStrong/ts-node/blob/3d103b71b1c7695fcc5f5bdb9bf3c018677dce55/package.json#L110-L112).
* View `package.json` to see the change

## Tasks:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
